### PR TITLE
Fix "owner" value so links to team page work properly in DevHub

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -15,4 +15,4 @@ metadata:
 spec:
   type: documentation
   lifecycle: experimental
-  owner: group:default/common-services-admin
+  owner: bcgov/common-services-admin


### PR DESCRIPTION
Fix "owner" value so links to team page work properly in DevHub. Currently, the link to team owning the doc is broken in Devhub. This change will fix so it displays.a team details page when clicked.