### PR TITLE
Non-elevated user restrictions; typos, markdown fixes etc.

### DIFF
--- a/docs/Config.md
+++ b/docs/Config.md
@@ -101,7 +101,7 @@ x-amz-endpoint: <endpoint>
 
 This mode is generally recommended for systems that need both user level and administrative level access to objects. This grants the full suite of functionality COMS offers, but care must be taken to ensure that access to objects is done securely from your line of business application.
 
-- Both OIDC and [Basic](#basic) and [OIDC](#oidc-keycloak) authentication modes are simultaneously enabled
+- Both [Basic](#basic) and [OIDC](#oidc-keycloak) authentication modes are simultaneously enabled
 
 ### Unauthenticated
 
@@ -127,7 +127,7 @@ In a multi-bucket COMS deployment (where buckets exist in the COMS database, in 
 
 COMS can be configured to run with a stricter content privacy masking. This is typically required when you want to limit object search results to just data that the current user has `READ` permission for.
 
-By default, COMS will run in the standard permissive mode, allowing for greater search and discovery features, unless the `SERVER_PRIVACY_MASK` environment variable is set to true.
+By default, COMS will run in the standard permissive mode, allowing for greater search and discovery features, unless the `SERVER_PRIVACY_MASK` environment variable is set to true:
 
 ```sh
   "server": {
@@ -135,6 +135,9 @@ By default, COMS will run in the standard permissive mode, allowing for greater 
     ...
   }
 ```
+
+!!! note
+    The following restrictions do not apply when the API request is authenticated using [basic authentication](#basic) or [S3 service account](Authentication.md#s3-service-account).
 
 When enabled, the COMS API endpoints that search for objects or list objects matching input parameters will not expose metadata or tags related to objects.
 
@@ -146,12 +149,51 @@ Requests to the following endpoints will scope the results to data related to ob
 - `GET /version/tagging`
 - `GET /version/metadata`
 
-In addition, the following two endpoints that search/list all tags (or metadata) that exist in a COMS database will only return the tag/metadata `Key` and not allow you to filter by `Value`:
+The endpoints that search and list all tags (or metadata) in a COMS database will only return the tag/metadata `Key`, and not allow you to filter by `Value`:
 
 - `GET /tagging`
 - `GET /metadata`
 
-All behaviour affected by this Privacy is ignored when the API request is authenticated using the [Basic](#basic) Authentication.
-
 !!! info
     For more details, please see the [COMS OpenAPI Specification](https://coms.api.gov.bc.ca/api/v1/docs#tag/Object/operation/readObject).
+
+### Additional restrictions on non-elevated users
+
+Additional restrictions apply to users that do not belong to a [list of "elevated" identity providers](https://github.com/bcgov/common-object-management-service/blob/master/app/src/components/constants.js#L31).
+
+!!! note
+    On the hosted service, only IDIR users are considered elevated users.
+
+Buckets cannot be created nor deleted, have their credentials updated, or synced:
+
+- `PUT /bucket`
+- `PATCH /bucket/:bucketId/`
+- `DELETE /bucket`
+- `GET /bucket/:bucketId/sync`
+
+Permissions cannot be added or removed:
+
+- `PUT /permission/bucket/:bucketId`
+- `PUT /permission/object/:objectId`
+- `PUT /permission/idp/bucket/:bucketId`
+- `PUT /permission/idp/object/:objectId`
+- `DELETE /permission/bucket/:bucketId`
+- `DELETE /permission/object/:objectId`
+- `DELETE /permission/idp/bucket/:bucketId`
+- `DELETE /permission/idp/object/:objectId`
+
+Buckets and objects cannot be made public or non-public:
+
+- `PATCH /bucket/:bucketId/public`
+- `PATCH /object/:objectId/public`
+
+Invitation tokens cannot be created:
+
+- `POST /permission/invite`
+
+Additionally, when searching for users (via the `GET /user` endpoint), one or more of the following paramters must be provided:
+
+- Complete email address
+- `userId`
+- `identityId`
+- `username`

--- a/docs/Hosted-Service-Onboarding.md
+++ b/docs/Hosted-Service-Onboarding.md
@@ -4,7 +4,7 @@ The COMS API is available as a hosted service for BC Government client applicati
 !!! info
     Not sure whether to use the shared hosted service, or use your own? [See here for a comparison](Hosting-Considerations.md).
     
-    If you want to self-host instead, [see here](Self-Hosting-COMS.md) to get started.
+    Self-hosting? [Get started here](Self-Hosting-COMS.md).
 
 Some important aspects of the hosted service to consider:
 

--- a/docs/Metadata-Tag.md
+++ b/docs/Metadata-Tag.md
@@ -23,7 +23,8 @@ Other general key notes to consider when implementing user-defined metadata are 
 - The size of user-defined metadata is measured by taking the sum of the number of bytes in the UTF-8 encoding of each key and value.
 - Avoid using characters outside the US-ASCII and UTF-8 standards for metadata values
 
-More details found here: [AWS: Working with object metadata](https://docs.aws.amazon.com/AmazonS3/latest/userguide/UsingMetadata.html)
+!!! info
+    Please see the [AWS documentation](https://docs.aws.amazon.com/AmazonS3/latest/userguide/UsingMetadata.html) for more details on working with S3 object metadata.
 
 ### Tag
 
@@ -37,7 +38,8 @@ Other general key notes to consider when implementing user-defined tags are the 
 - A tag value can be up to 256 Unicode characters in length.
 - Keys and values are case sensitive.
 
-More details found here: [AWS: Categorizing your storage using tags](https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-tagging.html)
+!!! info
+    Please see the [AWS documentation](https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-tagging.html) for more details on using S3 tags.
 
 ## Usage in COMS
 

--- a/docs/Permissions.md
+++ b/docs/Permissions.md
@@ -172,7 +172,7 @@ Optional email-user validation may also be specified to ensure the link is only 
 To create an invite link, the user must have the `MANAGE` permission on the resource being shared.
 
 !!! info
-  For more details on creating invite linkns, see the [OpenAPI specification](https://coms.api.gov.bc.ca/api/v1/docs#tag/Permission/operation/createInvite)
+    For more details on creating invite links, see the [OpenAPI specification](https://coms.api.gov.bc.ca/api/v1/docs#tag/Permission/operation/createInvite).
 
 ## Public access
 

--- a/docs/Use-Case-Examples.md
+++ b/docs/Use-Case-Examples.md
@@ -15,24 +15,23 @@ The following steps describe how a document management interface in your applica
 2. The user fills in a web form on your website attaching a document from their computer (a common user experience).
 3. When the user submits this web form, the client application sends a HTTP multipart/form-data POST to the [Create Object](https://coms.api.gov.bc.ca/api/v1/docs#tag/Object/operation/createObjects) endpoint (attaching the User A's JWT in an Authorization header).
 4. COMS will do the following:
-
-    1. Inspect the JWT and create a user record in the COMS database
-    2. Pass the file to an S3 bucket
-    3. Grant all PERMISSIONS to that user
+  1. Inspect the JWT and create a user record in the COMS database
+  2. Pass the file to an S3 bucket
+  3. Grant all permissions to that user
 
 #### Sharing a file
 
 The client application can do the following:
-    - Call the COMS [User Search](https://coms.api.gov.bc.ca/api/v1/docs#tag/User/operation/searchUsers) endpoint to return a list of matching users in the COMS database.
-    - Call the [Add Permission](https://coms.api.gov.bc.ca/api/v1/docs#tag/Permission/operation/objectAddPermissions) endpoint to grant a Government employee READ permission on the file.
+
+- Call the COMS [User Search](https://coms.api.gov.bc.ca/api/v1/docs#tag/User/operation/searchUsers) endpoint to return a list of matching users in the COMS database.
+- Call the [Add Permission](https://coms.api.gov.bc.ca/api/v1/docs#tag/Permission/operation/objectAddPermissions) endpoint to grant a Government employee READ permission on the file.
 
 #### Downloading a file
 
 1. `User B` logs in to the client application.
 2. Client application makes request to [Read Object](https://coms.api.gov.bc.ca/api/v1/docs#tag/Object/operation/readObject) endpoint (with User B's JWT in an Authorization header):
-
-    1. COMS will verify User B using the JWT and look up permissions for the file in the COMS database
-    2. COMS will then respond with a redirect to a pre-signed url to the source object in the storage server or allow direct download via proxy. Read the section on [OIDC AUthentication](Authentication.md#authentication-flow-for-readobject) for more details.
+  1. COMS will verify User B using the JWT and look up permissions for the file in the COMS database
+  2. COMS will then respond with a redirect to a pre-signed url to the source object in the storage server or allow direct download via proxy. Read the section on [OIDC Authentication](Authentication.md#authentication-flow-for-readobject) for more details.
 
 !!! info
-    For full implementation details of the COMS API, see the [GitHUb repository for BCBox](https://github.com/bcgov/bcbox).
+    For full implementation details of the COMS API, see the [GitHub repository for BCBox](https://github.com/bcgov/bcbox).


### PR DESCRIPTION
Add new section detailing restrictions on non-elevated users (i.e. non-IDIR).

Also fixed some Markdown lists, minor tweaks to wording, and a handful of additional callouts/admonitions created from existing content.